### PR TITLE
Add distribution name and distribution version.

### DIFF
--- a/mParticle-Apptentive/MPKitApptentive.m
+++ b/mParticle-Apptentive/MPKitApptentive.m
@@ -70,7 +70,7 @@ NSString * const APIKeyKey = @"appKey";
     dispatch_once(&kitPredicate, ^{
         NSString *APIKey = self.configuration[APIKeyKey];
 
-        [Apptentive sharedConnection].APIKey = APIKey;
+        [[Apptentive sharedConnection] setAPIKey:APIKey distributionName:@"mParticle" distributionVersion:[MParticle sharedInstance].version];
 
         _started = YES;
 


### PR DESCRIPTION
To help with product decisions, we try to track the ways in which customers are accessing Apptentive features. This tells our SDK that it is being accessed via mParticle along with the version of mParticle that is being used.