### PR TITLE
Update for version 4.0 of the Apptentive iOS SDK

### DIFF
--- a/mParticle-Apptentive.podspec
+++ b/mParticle-Apptentive.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "8.0"
     s.ios.source_files      = 'mParticle-Apptentive/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 6.11.0'
-    s.ios.dependency 'apptentive-ios', '~> 3.3.2'
+    s.ios.dependency 'apptentive-ios', '~> 4.0'
 end

--- a/mParticle-Apptentive/MPKitApptentive.m
+++ b/mParticle-Apptentive/MPKitApptentive.m
@@ -20,9 +20,9 @@
 #import "mParticle.h"
 
 #if defined(__has_include) && __has_include(<Apptentive/Apptentive.h>)
-    #import <Apptentive/Apptentive.h>
+#import <Apptentive/Apptentive.h>
 #else
-    #import "Apptentive.h"
+#import "Apptentive.h"
 #endif
 
 NSString * const AppKeyKey = @"apptentiveAppKey";

--- a/mParticle-Apptentive/MPKitApptentive.m
+++ b/mParticle-Apptentive/MPKitApptentive.m
@@ -19,13 +19,14 @@
 #import "MPKitApptentive.h"
 #import "mParticle.h"
 
-#if defined(__has_include) && __has_include(<apptentive-ios/Apptentive.h>)
-    #import <apptentive-ios/Apptentive.h>
+#if defined(__has_include) && __has_include(<Apptentive/Apptentive.h>)
+    #import <Apptentive/Apptentive.h>
 #else
     #import "Apptentive.h"
 #endif
 
-NSString * const APIKeyKey = @"appKey";
+NSString * const AppKeyKey = @"apptentiveAppKey";
+NSString * const AppSignatureKey = @"apptentiveAppSignature";
 
 @interface MPKitApptentive ()
 
@@ -56,7 +57,7 @@ NSString * const APIKeyKey = @"appKey";
 - (nonnull instancetype)initWithConfiguration:(nonnull NSDictionary *)configuration startImmediately:(BOOL)startImmediately {
     self = [super init];
     NSString *appKey = configuration[APIKeyKey];
-    if (!self || !appKey) {
+    if (!self || !appKey || !appSignature) {
         return nil;
     }
 
@@ -73,9 +74,14 @@ NSString * const APIKeyKey = @"appKey";
     static dispatch_once_t kitPredicate;
 
     dispatch_once(&kitPredicate, ^{
-        NSString *APIKey = self.configuration[APIKeyKey];
+        NSString *apptentiveKey = self.configuration[AppKeyKey];
+        NSString *apptentiveSignature = self.configuration[AppSignatureKey];
 
-        [[Apptentive sharedConnection] setAPIKey:APIKey distributionName:@"mParticle" distributionVersion:[MParticle sharedInstance].version];
+        ApptentiveConfiguration *configuration = [[ApptentiveConfiguration alloc] initWithApptentiveKey:[apptentiveKey apptentiveSignature:apptentiveSignature];
+        configuration.distributionName = @"mParticle";
+        configuration.distributionVersion = [MParticle sharedInstance].version;
+
+        [Apptentive registerWithConfiguration:configuration];
 
         _started = YES;
 

--- a/mParticle-Apptentive/MPKitApptentive.m
+++ b/mParticle-Apptentive/MPKitApptentive.m
@@ -56,9 +56,23 @@ NSString * const AppSignatureKey = @"apptentiveAppSignature";
 #pragma mark Kit instance and lifecycle
 - (nonnull instancetype)initWithConfiguration:(nonnull NSDictionary *)configuration startImmediately:(BOOL)startImmediately {
     self = [super init];
-    NSString *appKey = configuration[APIKeyKey];
-    if (!self || !appKey || !appSignature) {
+
+    if (self == nil) {
         return nil;
+    }
+
+    NSString *appKey = configuration[AppKeyKey];
+    NSString *appSignature = configuration[AppSignatureKey];
+    if (appKey == nil || appSignature == nil) {
+        if (appKey == nil) {
+            NSLog(@"No Apptentive App Key provided.");
+        }
+
+        if (appSignature == nil) {
+            NSLog(@"No Apptentive App Signature provided.");
+        }
+
+        NSLog(@"Please see the Apptentive mParticle integration guide: https://learn.apptentive.com/knowledge-base/mparticle-integration-ios/");
     }
 
     _configuration = configuration;
@@ -77,7 +91,7 @@ NSString * const AppSignatureKey = @"apptentiveAppSignature";
         NSString *apptentiveKey = self.configuration[AppKeyKey];
         NSString *apptentiveSignature = self.configuration[AppSignatureKey];
 
-        ApptentiveConfiguration *configuration = [[ApptentiveConfiguration alloc] initWithApptentiveKey:[apptentiveKey apptentiveSignature:apptentiveSignature];
+        ApptentiveConfiguration *configuration = [ApptentiveConfiguration configurationWithApptentiveKey:apptentiveKey apptentiveSignature:apptentiveSignature];
         configuration.distributionName = @"mParticle";
         configuration.distributionVersion = [MParticle sharedInstance].version;
 
@@ -124,26 +138,26 @@ NSString * const AppSignatureKey = @"apptentiveAppSignature";
             self.lastName = value;
         }
     } else {
-        [[Apptentive sharedConnection] addCustomPersonData:value withKey:key];
+        [[Apptentive sharedConnection] addCustomPersonDataString:value withKey:key];
     }
 
-	NSString *name = nil;
+    NSString *name = nil;
 
-	if (self.nameComponents) {
-		name = [self.nameFormatter stringFromPersonNameComponents:self.nameComponents];
-	} else {
-		if (self.firstName.length && self.lastName.length) {
-			name = [@[ self.firstName, self.lastName ] componentsJoinedByString:@" "];
-		} else if (self.firstName.length) {
-			name = self.firstName;
-		} else if (self.lastName.length) {
-			name = self.lastName;
-		}
-	}
+    if (self.nameComponents) {
+        name = [self.nameFormatter stringFromPersonNameComponents:self.nameComponents];
+    } else {
+        if (self.firstName.length && self.lastName.length) {
+            name = [@[ self.firstName, self.lastName ] componentsJoinedByString:@" "];
+        } else if (self.firstName.length) {
+            name = self.firstName;
+        } else if (self.lastName.length) {
+            name = self.lastName;
+        }
+    }
 
-	if (name) {
-		[Apptentive sharedConnection].personName = name;
-	}
+    if (name) {
+        [Apptentive sharedConnection].personName = name;
+    }
 
     MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeSuccess];
     return execStatus;


### PR DESCRIPTION
This bumps the pod dependency to 4.0 and updates the handling of initializing the SDK to include the new Apptentive App Key and Apptentive App Signature. 