### PR TITLE
Fix a bug where configuration wasn't saved and Apptentive SDK wouldn't start

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+osx_image: xcode7.3
+language: objective-c
+script:
+- pod repo update > /dev/null
+- pod lib lint --use-libraries

--- a/mParticle-Apptentive.podspec
+++ b/mParticle-Apptentive.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-Apptentive"
-    s.version          = "6.3.0"
+    s.version          = "6.4.0"
     s.summary          = "Apptentive integration for mParticle"
 
     s.description      = <<-DESC
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
 
     s.ios.deployment_target = "7.0"
     s.ios.source_files      = 'mParticle-Apptentive/*.{h,m,mm}'
-    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 6.3'
-    s.ios.dependency 'apptentive-ios', '~> 3.1'
+    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 6.4'
+    s.ios.dependency 'apptentive-ios', '~> 3.2'
 end


### PR DESCRIPTION
This is a fix for a pretty serious bug that was introduced by me in a conflict-resolution-gone-bad last summer. 

The bug removed the line where we save the configuration argument to the object's property, so the kit would appear to launch successfully but under the hood the Apptentive SDK would fail to launch. 

I have also extracted the execStatus code into its own method as in your kit example project. 