### PR TITLE
Added ability to delay Apptentive SDK initialization

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "apptentive/apptentive-ios" ~> 5.1
+github "apptentive/apptentive-ios" ~> 5.2
 github "mparticle/mparticle-apple-sdk" ~> 7.9.0

--- a/mParticle-Apptentive.podspec
+++ b/mParticle-Apptentive.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-Apptentive/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 7.9.0'
-    s.ios.dependency 'apptentive-ios', '~> 5.1'
+    s.ios.dependency 'apptentive-ios', '~> 5.2'
 end

--- a/mParticle-Apptentive/MPKitApptentive.h
+++ b/mParticle-Apptentive/MPKitApptentive.h
@@ -33,6 +33,14 @@
 @property (nonatomic, strong, nullable) NSDictionary<NSString *, id> *userAttributes;
 @property (nonatomic, strong, nullable) NSArray<NSDictionary<NSString *, id> *> *userIdentities;
 
+
+/**
+ Begins Apptentive SDK initialization. Does nothing is the SDK is already initialized.
+
+ @return YES if SDK initialization was successful. NO - if SDK was already initialized or failed to initialize.
+ */
++ (BOOL)registerSDK;
+
 @end
 
 @interface Apptentive ()

--- a/mParticle-Apptentive/MPKitApptentive.h
+++ b/mParticle-Apptentive/MPKitApptentive.h
@@ -35,9 +35,9 @@
 
 
 /**
- Begins Apptentive SDK initialization. Does nothing is the SDK is already initialized.
+ Begins Apptentive SDK initialization. Does nothing if the SDK is already initialized.
 
- @return YES if SDK initialization was successful. NO - if SDK was already initialized or failed to initialize.
+ @return YES if SDK initialization was successful. NO - if the SDK was already initialized or failed to initialize.
  */
 + (BOOL)registerSDK;
 


### PR DESCRIPTION
The Apptentive kit reads an optional configuration flag `apptentiveInitOnStart` to determine if the SDK should be registered at the startup. If the flag is missing or set to `1`, the SDK would be initialized as usual. If the flag is set to `0`, the customer would have to call `[MPKitApptentive registerSDK]` when it's appropriate to register Apptentive SDK.