### PR TITLE
Fix missing call to addObserver

### DIFF
--- a/mParticle-Apptentive/MPKitApptentive.m
+++ b/mParticle-Apptentive/MPKitApptentive.m
@@ -99,6 +99,8 @@ NSString * const ApptentiveConversationStateDidChangeNotification = @"Apptentive
 
         [Apptentive registerWithConfiguration:apptentiveConfig];
 
+        [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(conversationStateChangedNotification:) name:ApptentiveConversationStateDidChangeNotification object:nil];
+
         self->_started = YES;
 
         if ([NSPersonNameComponents class]) {


### PR DESCRIPTION
Due to some trouble with a merge conflict, we introduced a bug that resulted in the customer identifier not being saved by our SDK. 

This PR restores that functionality. 