### PR TITLE
Update for xcode 12

### DIFF
--- a/mParticle-Apptentive.podspec
+++ b/mParticle-Apptentive.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-Apptentive/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 7.0'
-    s.ios.dependency 'apptentive-ios', '~> 5.2'
+    s.ios.dependency 'apptentive-ios', '~> 5.3'
 end

--- a/mParticle-Apptentive/MPKitApptentive.m
+++ b/mParticle-Apptentive/MPKitApptentive.m
@@ -99,6 +99,8 @@ NSString * const ApptentiveConversationStateDidChangeNotification = @"Apptentive
 
         [Apptentive registerWithConfiguration:apptentiveConfig];
 
+        [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(conversationStateChangedNotification:) name:ApptentiveConversationStateDidChangeNotification object:nil];
+
         self->_started = YES;
 
         if ([NSPersonNameComponents class]) {


### PR DESCRIPTION
Apptentive SDK versions prior to 5.3.0 have a crashing bug in Surveys when built with Xcode 12 and run on iOS 14, so we'd like to get folks to update to 5.3 or later ASAP. 