### PR TITLE
Bump ApptentiveKit version in podspec

### DIFF
--- a/mParticle-Apptentive.podspec
+++ b/mParticle-Apptentive.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "11.0"
     s.ios.source_files      = 'mParticle-Apptentive/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.7'
-    s.ios.dependency 'ApptentiveKit', '~> 6.0.2'
+    s.ios.dependency 'ApptentiveKit', '~> 6.1.0'
 end


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Updates the ApptentiveKit transitive dependency to version 6.1.0

 ## Testing Plan
 - Ran `pod update`, ran a test app, saw no issues when initializing and passing events to the integration, and likewise no issues with directly accessing the ApptentiveKit SDK.
