### PR TITLE
chore: Update ApptentiveKit dependency to v6.2

### DIFF
--- a/mParticle-Apptentive.podspec
+++ b/mParticle-Apptentive.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "11.0"
     s.ios.source_files      = 'mParticle-Apptentive/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.7'
-    s.ios.dependency 'ApptentiveKit', '~> 6.0.2'
+    s.ios.dependency 'ApptentiveKit', '~> 6.1.0'
 end

--- a/mParticle-Apptentive.podspec
+++ b/mParticle-Apptentive.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "11.0"
     s.ios.source_files      = 'mParticle-Apptentive/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.7'
-    s.ios.dependency 'ApptentiveKit', '~> 6.2.0'
+    s.ios.dependency 'ApptentiveKit', '~> 6.2'
 end

--- a/mParticle-Apptentive.podspec
+++ b/mParticle-Apptentive.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "11.0"
     s.ios.source_files      = 'mParticle-Apptentive/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.7'
-    s.ios.dependency 'ApptentiveKit', '~> 6.1.0'
+    s.ios.dependency 'ApptentiveKit', '~> 6.2.0'
 end


### PR DESCRIPTION
 ## Summary
 - Changes podspec dependency for ApptentiveKit to version 6.2.x

 ## Testing Plan
 - Basic functionality tested by integrating into example app
