### PR TITLE
feat: Improve Privacy Manifest support for iOS 17

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,3 @@
-github "apptentive/apptentive-kit-ios" ~> 6.0
-github "mparticle/mparticle-apple-sdk" ~> 8.0
+github "apptentive/apptentive-kit-ios" ~> 6.6
+binary "https://raw.githubusercontent.com/mParticle/mparticle-apple-sdk/main/mParticle_Apple_SDK.json" ~> 8.22
+

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
       .package(url: "https://github.com/mParticle/mparticle-apple-sdk",
-               .upToNextMajor(from: "8.0.0")),
+               .upToNextMajor(from: "8.22.0")),
       .package(url: "https://github.com/apptentive/apptentive-kit-ios",
                .upToNextMajor(from: "6.6.0")),
     ],
@@ -26,6 +26,7 @@ let package = Package(
             ],
             path: "mParticle-Apptentive",
             exclude: ["Info.plist"],
+            resources: [.process("PrivacyInfo.xcprivacy")],
             publicHeadersPath: "."),
     ]
 )

--- a/mParticle-Apptentive.podspec
+++ b/mParticle-Apptentive.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
     s.swift_version = "5.5"
     s.ios.deployment_target = "13.0"
     s.ios.source_files      = 'mParticle-Apptentive/*.{h,m,mm}'
-    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.7'
+    s.ios.resource_bundles  = { 'mParticle-Apptentive-Privacy' => ['mParticle-Apptentive/PrivacyInfo.xcprivacy'] }
+    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.22'
     s.ios.dependency 'ApptentiveKit', '~> 6.6'
 end

--- a/mParticle-Apptentive.xcodeproj/project.pbxproj
+++ b/mParticle-Apptentive.xcodeproj/project.pbxproj
@@ -3,16 +3,16 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		53C0DA722BEAA5F400356F52 /* ApptentiveKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53C0DA702BEAA5F400356F52 /* ApptentiveKit.xcframework */; };
+		53C0DA732BEAA5F400356F52 /* mParticle_Apple_SDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53C0DA712BEAA5F400356F52 /* mParticle_Apple_SDK.xcframework */; };
 		D330F1682BBEE0AC005CB4CD /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D330F1672BBEE0AC005CB4CD /* PrivacyInfo.xcprivacy */; };
-		D37EFA8724F430580091B75B /* ApptentiveKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB695FB21F5F549A00A7F4CF /* ApptentiveKit.framework */; platformFilter = ios; };
 		DB7E05A61CB819D300967FDF /* MPKitApptentive.h in Headers */ = {isa = PBXBuildFile; fileRef = DB7E05A41CB819D300967FDF /* MPKitApptentive.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB7E05A71CB819D300967FDF /* MPKitApptentive.m in Sources */ = {isa = PBXBuildFile; fileRef = DB7E05A51CB819D300967FDF /* MPKitApptentive.m */; };
 		DB9401701CB703F2007ABB18 /* mParticle_Apptentive.h in Headers */ = {isa = PBXBuildFile; fileRef = DB94016F1CB703F2007ABB18 /* mParticle_Apptentive.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DB94017A1CB70C58007ABB18 /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB9401781CB70C58007ABB18 /* mParticle_Apple_SDK.framework */; };
 		EF233800263F3F0F004B1C55 /* mParticle_ApptentiveTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EF2337FF263F3F0F004B1C55 /* mParticle_ApptentiveTests.m */; };
 		EF233802263F3F0F004B1C55 /* mParticle_Apptentive.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB94016C1CB703F2007ABB18 /* mParticle_Apptentive.framework */; };
 		EF23381E263F48B2004B1C55 /* MPKitApptentiveUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = EF23381C263F48B2004B1C55 /* MPKitApptentiveUtils.h */; };
@@ -30,14 +30,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		53C0DA702BEAA5F400356F52 /* ApptentiveKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ApptentiveKit.xcframework; path = Carthage/Build/ApptentiveKit.xcframework; sourceTree = "<group>"; };
+		53C0DA712BEAA5F400356F52 /* mParticle_Apple_SDK.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:DLD43Y3TRP:mParticle, inc"; lastKnownFileType = wrapper.xcframework; name = mParticle_Apple_SDK.xcframework; path = Carthage/Build/mParticle_Apple_SDK.xcframework; sourceTree = "<group>"; };
 		D330F1672BBEE0AC005CB4CD /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		DB695FB21F5F549A00A7F4CF /* ApptentiveKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ApptentiveKit.framework; path = Carthage/Build/iOS/ApptentiveKit.framework; sourceTree = "<group>"; };
 		DB7E05A41CB819D300967FDF /* MPKitApptentive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPKitApptentive.h; sourceTree = "<group>"; };
 		DB7E05A51CB819D300967FDF /* MPKitApptentive.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPKitApptentive.m; sourceTree = "<group>"; };
 		DB94016C1CB703F2007ABB18 /* mParticle_Apptentive.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = mParticle_Apptentive.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB94016F1CB703F2007ABB18 /* mParticle_Apptentive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mParticle_Apptentive.h; sourceTree = "<group>"; };
 		DB9401711CB703F2007ABB18 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		DB9401781CB70C58007ABB18 /* mParticle_Apple_SDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = mParticle_Apple_SDK.framework; path = Carthage/Build/iOS/mParticle_Apple_SDK.framework; sourceTree = "<group>"; };
 		EF2337FD263F3F0F004B1C55 /* mParticle-ApptentiveTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "mParticle-ApptentiveTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EF2337FF263F3F0F004B1C55 /* mParticle_ApptentiveTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = mParticle_ApptentiveTests.m; sourceTree = "<group>"; };
 		EF233801263F3F0F004B1C55 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -50,8 +50,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D37EFA8724F430580091B75B /* ApptentiveKit.framework in Frameworks */,
-				DB94017A1CB70C58007ABB18 /* mParticle_Apple_SDK.framework in Frameworks */,
+				53C0DA722BEAA5F400356F52 /* ApptentiveKit.xcframework in Frameworks */,
+				53C0DA732BEAA5F400356F52 /* mParticle_Apple_SDK.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -69,8 +69,8 @@
 		DB9401621CB703F2007ABB18 = {
 			isa = PBXGroup;
 			children = (
-				DB695FB21F5F549A00A7F4CF /* ApptentiveKit.framework */,
-				DB9401781CB70C58007ABB18 /* mParticle_Apple_SDK.framework */,
+				53C0DA702BEAA5F400356F52 /* ApptentiveKit.xcframework */,
+				53C0DA712BEAA5F400356F52 /* mParticle_Apple_SDK.xcframework */,
 				DB94016E1CB703F2007ABB18 /* mParticle-Apptentive */,
 				EF2337FE263F3F0F004B1C55 /* mParticle-ApptentiveTests */,
 				DB94016D1CB703F2007ABB18 /* Products */,

--- a/mParticle-Apptentive/PrivacyInfo.xcprivacy
+++ b/mParticle-Apptentive/PrivacyInfo.xcprivacy
@@ -7,12 +7,8 @@
     <key>NSPrivacyTrackingDomains</key>
     <array/>
     <key>NSPrivacyCollectedDataTypes</key>
-    <array>
-        <dict/>
-    </array>
+    <array/>
     <key>NSPrivacyAccessedAPITypes</key>
-    <array>
-        <dict/>
-    </array>
+    <array/>
 </dict>
 </plist>

--- a/mParticle-Apptentive/mParticle_Apptentive.h
+++ b/mParticle-Apptentive/mParticle_Apptentive.h
@@ -8,4 +8,8 @@ FOUNDATION_EXPORT const unsigned char mParticle_ApptentiveVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <mParticle_Apptentive/PublicHeader.h>
 
-#import <mParticle_Apptentive/MPKitApptentive.h>
+#if defined(__has_include) && __has_include(<mParticle_Apptentive/MPKitApptentive.h>)
+    #import <mParticle_Apptentive/MPKitApptentive.h>
+#else
+    #import "MPKitApptentive.h"
+#endif


### PR DESCRIPTION
 ## Summary
 - Fix parsing issue due to empty dict
 
NOTE: Apptentive is not correctly referencing their privacy manifest in either SPM or CocoaPods, it only currently works in Carthage. There is an open issue here where I've replied with fix instructions: https://github.com/apptentive/apptentive-kit-ios/issues/53#issuecomment-2099057780

If they release they fix as a minor or patch release, which is likely, then we'll get it automatically. We'll be keeping an eye on their releases in the meantime.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Confirmed in test apps

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6413